### PR TITLE
Switch to Ubuntu for Android workflows

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest # to take advantage of hardware acceleration
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -30,6 +30,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      # Kernel-based Virtual Machine (to enhance the performance of AVDs)
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
# Problem

Android workflows are the slowest of the 4 mobile pipelines (averaging 15 minutes per job) and the most flaky. It can often take a whole day with 20+ attempts to get all the Android tests to pass, despite all the tests working fine locally. The errors vary but are often due to the emulator crashing or not responding to UI commands. This happens more often on newer Android versions. Also, using macOS runners limits the amount of workflows that can run in parallel (up to 5).

# Solution

A few months ago, GitHub-hosted runners got upgraded to [4-vCPU runners](https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/), up from 2 previously. And now `android-emulator-runner` recommends using Linux runners since they perform better than macOS runners.

By following [their guidelines](https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners), we can switch to `ubuntu-latest` and enable KVM (Kernel-based Virtual Machines) for improved performance.

# Test Plan

The goal is to have the workflows run faster and provide more reliable results. Since we're switching to Linux, all 6 workflows can start simultaneously. If this works, we can copy this change to [ez-recipes-android](https://github.com/Abhiek187/ez-recipes-android).